### PR TITLE
Fix/support gtpv2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ help: ## Show this help.
 	@echo ''
 	@echo 'Targets:'
 	@awk 'BEGIN {FS = ":.*?## "} { \
-		if (/^[a-zA-Z_-]+:.*?##.*$$/) {printf "    ${YELLOW}%-20s${GREEN}%s${RESET}\n", $$1, $$2} \
+		if (/^[a-zA-Z_0-9-]+:.*?##.*$$/) {printf "    ${YELLOW}%-20s${GREEN}%s${RESET}\n", $$1, $$2} \
 		else if (/^## .*$$/) {printf "  ${CYAN}%s${RESET}\n", substr($$1,4)} \
 		}' $(MAKEFILE_LIST)
 

--- a/example/echo-stress.js
+++ b/example/echo-stress.js
@@ -1,17 +1,22 @@
 import { check } from 'k6';
+import exec from 'k6/execution';
+
 import gtpv2 from 'k6/x/gtpv2';
-const client = new gtpv2.K6GTPv2Client();
+
+let client;
 
 export default function (){
-    client.connect({
-        saddr: "127.0.0.1:2124",
-        daddr: "127.0.0.1:2123",
-        count: 0,
-        IFTypeName: "IFTypeS5S8PGWGTPC"
-    });
+    if (client == null) {
+        client = new gtpv2.K6GTPv2Client();
+        client.connect({
+            saddr: `127.0.0.${exec.vu.idInTest}:2124`,
+            daddr: "127.0.0.1:2123",
+            count: 0,
+            IFTypeName: "IFTypeS5S8PGWGTPC"
+        });
+    }
     const res = client.checkSendEchoRequestWithReturnResponse("127.0.0.1:2123")
     check (res, {
         'success': (res) => true === res,
     });
-    client.close()
 }


### PR DESCRIPTION
# What
とりあえず挙動を治すだけやりました。
もしかしたら unsafe.Pointer経由してグローバルなテーブルを避けられるかも知れません。
channelつかってConnごとのsync.Mapの利用を避けるとかできそうです。などなど改善点は多数 :bow:

- `make help` で`xk6build`を表示するようにした
- シナリオ定義(JavaScript)から正しい値を受け取れるようにした
    - goja的ルールにアノテーションを揃えた
- PGWCからのレスポンスを受け取れるように変更した
    - Connにハンドラを追加してseqに合わせて保存、呼び出し側でres取得でseqを使って取り出し
        - **面倒なのでspinさせる**

# Why
ちゃんと受け取れてないから。


# Merge condition
- xk6サブプロジェクトメンバーの合意