### PR TITLE
Modified to send CSReq and respond CSRes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ make build
 ## Support scenario
 ### GTPv2-C
 - [x] Node monitoring (Echo Request/Echo Response)
-- [ ] Create Session  (Create Session Request/Create Session Response)
+- [x] Create Session  (Create Session Request/Create Session Response)
 - [ ] Delete Session (Delete Session Request/Delete Session Response)
 - [ ] Modify Bearer (Modify Bearer Request/Modify Bearer Response)
 - [ ] Delete Bearer (Delete Bearer Request/Delete Bearer Response)

--- a/cmd/pgw/pgw.go
+++ b/cmd/pgw/pgw.go
@@ -2,6 +2,8 @@
 package main
 
 import (
+	"crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"log"
 	"net"
@@ -174,7 +176,9 @@ func handleCreateSessionRequest(c *gtpv2.Conn, sgwAddr net.Addr, msg message.Mes
 	// PGW Cplane TEID
 	s5cFTEID := c.NewSenderFTEID(cIP, "").WithInstance(1)
 	// PGW Uplane TEID
-	s5uFTEID := uConn.NewFTEID(gtpv2.IFTypeS5S8PGWGTPU, uIP, "").WithInstance(2)
+	// s5uFTEID := uConn.NewFTEID(gtpv2.IFTypeS5S8PGWGTPU, uIP, "").WithInstance(2)
+	// uConnを作成する箇所がなく未使用のため、直接別関数でTEIDのみを生成
+	s5uFTEID := ie.NewFullyQualifiedTEID(gtpv2.IFTypeS5S8PGWGTPU, generateRandomUint32(), uIP, "")
 	// SGW Cplane TEID
 	s5sgwTEID, err := session.GetTEID(gtpv2.IFTypeS5S8SGWGTPC)
 	if err != nil {
@@ -278,4 +282,13 @@ func handleDeleteSessionRequest(c *gtpv2.Conn, sgwAddr net.Addr, msg message.Mes
 	loggerCh <- fmt.Sprintf("Session deleted for Subscriber: %s", session.IMSI)
 	c.RemoveSession(session)
 	return nil
+}
+
+func generateRandomUint32() uint32 {
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		return 0
+	}
+
+	return binary.BigEndian.Uint32(b)
 }

--- a/example/s5s8pgw-stress.js
+++ b/example/s5s8pgw-stress.js
@@ -1,23 +1,40 @@
+import { check } from 'k6';
+import exec from 'k6/execution';
+
 import gtpv2 from 'k6/x/gtpv2';
 
-// pseudo sgw
-export function setup() {
-    gtpv2.connect({
-        saddr: 'SRC_IP',
-        daddr: "DST_IP",
-        count: "RETRY_NUM",
-        IFTypeName: "IFTypeS5S8PGWGTPC"
-    })
-    console.log("setup");
-}
+let client;
 
-export default function () {
-    const res = gtpv2.SendCreateSessionRequestS5S8(
-        "DST_IP",
-        {},
+export default function (){
+    if (client == null) {
+        client = new gtpv2.K6GTPv2Client();
+        client.connect({
+            saddr: `127.0.0.${exec.vu.idInTest}:2124`,
+            daddr: "127.0.0.1:2125",
+            count: 0,
+            IFTypeName: "IFTypeS5S8PGWGTPC"
+        });
+    }
+    const res = client.sendCreateSessionRequestS5S8(
+        "127.0.0.1:2125",
+         {
+            imsi: "123451234567891",
+            msisdn: "123451234567891",
+            mei: "123451234567891",
+            mcc: "123",
+            mnc: "123",
+            tac: 1,
+            rat: "EUTRAN",
+            apn: "apn",
+            eci: 1,
+            epsbearerid: 1,
+            uplaneteid: 1,
+            ambrul: 100000000,
+            ambrdl: 100000000,
+        }
     )
     check (res, {
         'success': (res) => true === res,
     });
-    gtpv2.close()
+    client.close()
 }

--- a/example/s5s8pgw-stress.js
+++ b/example/s5s8pgw-stress.js
@@ -15,7 +15,7 @@ export default function (){
             IFTypeName: "IFTypeS5S8PGWGTPC"
         });
     }
-    const res = client.sendCreateSessionRequestS5S8(
+    const res = client.checkSendCreateSessionRequestS5S8(
         "127.0.0.1:2125",
          {
             imsi: "123451234567891",

--- a/pkg/gtpv2/gtpv2.go
+++ b/pkg/gtpv2/gtpv2.go
@@ -172,26 +172,26 @@ func (c *K6GTPv2Client) SendCreateSessionRequest(daddr string, ie ...*ie.IE) (*g
 }
 
 type S5S8SgwParams struct {
-	IMSI        string
-	MSISDN      string
-	MEI         string
-	ULI         string
-	MCC         string
-	MNC         string
-	TAC         uint16
-	ECGI        string
-	RAT         string
-	FTEI        string
-	APN         string
-	ECI         uint32
-	EPSBearerID uint8
-	UplaneTEID  uint32
-	AMBRUL      uint32
-	AMBRDL      uint32
+	Imsi   string
+	Msisdn string
+	Mei    string
+	// ULI         string
+	Mcc         string
+	Mnc         string
+	Tac         uint16
+	Ecgi        string
+	Rat         string
+	Ftei        string
+	Apn         string
+	Eci         uint32
+	Epsbearerid uint8
+	Uplaneteid  uint32
+	Ambrul      uint32
+	Ambrdl      uint32
 }
 
 func (c *K6GTPv2Client) SendCreateSessionRequestS5S8(daddr string, options S5S8SgwParams) (*gtpv2.Session, error) {
-	d, err := net.ResolveIPAddr("udp", daddr)
+	d, err := net.ResolveUDPAddr("udp", daddr)
 	if err != nil {
 		return nil, fmt.Errorf("resolve udp error")
 	}
@@ -199,27 +199,27 @@ func (c *K6GTPv2Client) SendCreateSessionRequestS5S8(daddr string, options S5S8S
 	localIP := strings.Split(c.Conn.LocalAddr().String(), ":")[0]
 
 	sess, _, err := c.Conn.CreateSession(d,
-		ie.NewIMSI(options.IMSI),
-		ie.NewMSISDN(options.MSISDN),
-		ie.NewMobileEquipmentIdentity(options.MEI),
-		ie.NewAccessPointName(options.APN),
-		ie.NewServingNetwork(options.MCC, options.MNC),
+		ie.NewIMSI(options.Imsi),
+		ie.NewMSISDN(options.Msisdn),
+		ie.NewMobileEquipmentIdentity(options.Mei),
+		ie.NewAccessPointName(options.Apn),
+		ie.NewServingNetwork(options.Mcc, options.Mnc),
 		ie.NewRATType(gtpv2.RATTypeEUTRAN),
 		c.Conn.NewSenderFTEID(localIP, ""), // todo v6
 		ie.NewSelectionMode(gtpv2.SelectionModeMSorNetworkProvidedAPNSubscribedVerified),
 		ie.NewPDNType(gtpv2.PDNTypeIPv4),
 		ie.NewPDNAddressAllocation("0.0.0.0"),
 		ie.NewAPNRestriction(gtpv2.APNRestrictionPublic2),
-		ie.NewAggregateMaximumBitRate(options.AMBRUL, options.AMBRDL),
+		ie.NewAggregateMaximumBitRate(options.Ambrul, options.Ambrdl),
 		ie.NewUserLocationInformationStruct(
 			nil, nil, nil,
-			ie.NewTAI(options.MCC, options.MNC, options.TAC),
-			ie.NewECGI(options.MCC, options.MNC, options.ECI),
+			ie.NewTAI(options.Mcc, options.Mnc, options.Tac),
+			ie.NewECGI(options.Mcc, options.Mnc, options.Eci),
 			nil, nil, nil,
 		),
 		ie.NewBearerContext(
-			ie.NewEPSBearerID(options.EPSBearerID),
-			ie.NewFullyQualifiedTEID(gtpv2.IFTypeS5S8PGWGTPU, options.UplaneTEID, localIP, "").WithInstance(1), //dummy uplane teid
+			ie.NewEPSBearerID(options.Epsbearerid),
+			ie.NewFullyQualifiedTEID(gtpv2.IFTypeS5S8PGWGTPU, options.Uplaneteid, localIP, "").WithInstance(1), //dummy uplane teid
 			ie.NewBearerQoS(1, 2, 1, 0xff, 0, 0, 0, 0),
 		),
 		ie.NewFullyQualifiedCSID(localIP, 1).WithInstance(1),


### PR DESCRIPTION
<!-- This is just a template, so you can change it to whatever format you like. (What, Why, Related issues, if possible)-->

# What
- [x] pgw.go内でPGW Uplane TEIDを作成時にuConn情報も含め作成する必要があったが、現状uConnを作成する処理がないため、暫定対処としてPGW Uplane TEIDのみを作成
- [x] CSRに必要な送信情報をs5s8pgw-stress.jsを修正し作成
- SendCreateSessionRequestS5S8関数の引数に不足分（複数IE）があったため主にそれらを追加
- [x] ResolveIPAddr→ResolveUDPAddrに修正 

# Why
CSReq送信による負荷試験を今後実施するため

# How

# Merge condition
xk6-mobile-plugin PJメンバーのどなたかのapprove

# Related issues