### PR TITLE
fix: entrypoint of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ WORKDIR /app
 COPY --from=builder --chown=k6:k6 /go/bin/k6 ./
 COPY --from=builder --chown=k6:k6 /go/src/app ./
 
-ENTRYPOINT [ "k6" ]
+ENTRYPOINT [ "/app/k6" ]


### PR DESCRIPTION
<!-- This is just a template, so you can change it to whatever format you like. (What, Why, Related issues, if possible)-->

# What
<!-- Changed contents, if possible something easy to understand that can be evidence of the change. (e.g. screen changes, implementation process dumps, etc.)-->

This PR make a change to set entrypoint from relative path to full binary path.

- [x] fix entrypoint of Dockerfile

# Why
<!-- Write the purpose of the change and related stories (e.g. the screen is hard to see, the user wants something like this) -->

docker image not working
```
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "k6": executable file not found in $PATH: unknown.
```

# How
<!-- Changes to this function affect this function, environment variables required for operation / dependencies / DB updates, etc. Points to look at when reviewing, points to note when trying in a local environment, etc. -->

container image need update (not working now)

# Merge condition
<!-- Who approves to merge, etc. -->

- someone