### PR TITLE
fix: update golangci-lint and migrate v2 configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,53 +1,67 @@
+version: "2"
 run:
-  timeout: 15m
   build-tags:
     - vrf_test
     - xdp_test
-
-output:
-  sort-results: true
-
 linters:
   enable:
     - depguard
     - gocritic
-    - gofumpt
-    - goimports
     - misspell
     - predeclared
     - revive
     - unconvert
-    - unused
-
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: github.com/stretchr/testify/assert
+              desc: Use github.com/stretchr/testify/require instead of github.com/stretchr/testify/assert
+            - pkg: io/ioutil
+              desc: Use corresponding 'os' or 'io' functions instead.
+    errcheck:
+      exclude-functions:
+        - example/**
+    revive:
+      rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
+        - name: unused-parameter
+          severity: warning
+          disabled: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - errcheck
+        path: _test.go
+      - linters:
+          - staticcheck
+        path: tools.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   max-same-issues: 0
-  exclude-rules:
-    - path: _test.go
-      linters:
-        - errcheck
-    - path: tools.go
-      linters:
-        - stylecheck
-
-linters-settings:
-  depguard:
-    rules:
-      main:
-        deny:
-        - pkg: "github.com/stretchr/testify/assert"
-          desc: "Use github.com/stretchr/testify/require instead of github.com/stretchr/testify/assert"
-        - pkg: "io/ioutil"
-          desc: "Use corresponding 'os' or 'io' functions instead."
-  errcheck:
-    exclude-functions:
-      - example/**
-  goimports:
-    local-prefixes: github.com/bbsakura
-  gofumpt:
-    extra-rules: true
-  revive:
-    rules:
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
-      - name: unused-parameter
-        severity: warning
-        disabled: true
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      extra-rules: true
+    goimports:
+      local-prefixes:
+        - github.com/bbsakura
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/scripts/install-go-tools.sh
+++ b/scripts/install-go-tools.sh
@@ -3,7 +3,7 @@
 go install github.com/dmarkham/enumer@v1.5.11
 go install github.com/elisescu/tty-share@v0.6.2
 go install github.com/erkanzileli/co-author@v0.0.7
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.4.0
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
 go install go.k6.io/xk6/cmd/xk6@v0.13.4
 go install golang.org/x/tools/cmd/goimports@v0.35.0
 go install golang.org/x/tools/cmd/stringer@v0.35.0


### PR DESCRIPTION

# What
<!-- Changed contents, if possible something easy to understand that can be evidence of the change. (e.g. screen changes, implementation process dumps, etc.)-->
- [x] migrate golangci-lint configuration
