### PR TITLE
chore: fix linter error

### DIFF
--- a/cmd/pgw/pgw.go
+++ b/cmd/pgw/pgw.go
@@ -172,7 +172,7 @@ func handleCreateSessionRequest(c *gtpv2.Conn, sgwAddr net.Addr, msg message.Mes
 
 	// PGW Cplane TEID
 	var s5cFTEID *ie.IE
-	if session.Subscriber.IMEI == "123451234567895" { // testing only
+	if session.IMEI == "123451234567895" { // testing only
 		s5cFTEID = ie.NewFullyQualifiedTEID(gtpv2.IFTypeS5S8PGWGTPC, 111, uIP, "").WithInstance(1)
 	} else {
 		s5cFTEID = c.NewSenderFTEID(cIP, "").WithInstance(1)
@@ -218,7 +218,7 @@ func handleCreateSessionRequest(c *gtpv2.Conn, sgwAddr net.Addr, msg message.Mes
 	}
 
 	loggerCh <- fmt.Sprintf("Session created with S-GW for subscriber: %s;\n\tS5C S-GW: %s, TEID->: %#x, TEID<-: %#x",
-		session.Subscriber.IMSI, sgwAddr, s5sgwTEID, s5pgwTEID,
+		session.IMSI, sgwAddr, s5sgwTEID, s5pgwTEID,
 	)
 	return nil
 }
@@ -276,7 +276,7 @@ func handleModifyBearerRequest(c *gtpv2.Conn, sgwAddr net.Addr, msg message.Mess
 		return &gtpv2.RequiredIEMissingError{Type: ie.FullyQualifiedTEID}
 	}
 
-	seqn := reqFromSGW.Header.SequenceNumber
+	seqn := reqFromSGW.SequenceNumber
 
 	// cause: context not found
 	// TODO...


### PR DESCRIPTION
This pull request makes minor corrections to field accesses and improves code clarity in the `cmd/pgw/pgw.go` file. The changes mostly involve updating struct field references to use the correct field names, which helps prevent bugs and maintain consistency.

Most important changes:

**Field Reference Corrections:**

* Changed references from `session.Subscriber.IMEI` and `session.Subscriber.IMSI` to `session.IMEI` and `session.IMSI` in the `handleCreateSessionRequest` function to use the correct struct fields. [[1]](diffhunk://#diff-fa1c8de9df27b3628f70db109417f26146338ba3a59b302ab49bb69a0924fd24L175-R175) [[2]](diffhunk://#diff-fa1c8de9df27b3628f70db109417f26146338ba3a59b302ab49bb69a0924fd24L221-R221)

**Code Clarity and Consistency:**

* Updated the sequence number reference from `reqFromSGW.Header.SequenceNumber` to `reqFromSGW.SequenceNumber` in the `handleModifyBearerRequest` function for clearer and more direct access.